### PR TITLE
Copy file if symlinking fails

### DIFF
--- a/src/ScriptSymlinker.php
+++ b/src/ScriptSymlinker.php
@@ -56,7 +56,9 @@ class ScriptSymlinker
 
                     $event->getIO()->write("  Symlinking <comment>$targetPath</comment> to <comment>$linkPath</comment>");
                     $fs->ensureDirectoryExists(dirname($linkPath));
-                    $fs->relativeSymlink($targetPath, $linkPath);
+                    if (!$fs->relativeSymlink($targetPath, $linkPath) && !is_dir($targetPath)) {
+                        copy($targetPath, $linkPath);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Solved issue #2: Fallback mechanism for filesystems that do not support symlinks (for example: Windows)