### PR TITLE
Optimized symlink to package matching

### DIFF
--- a/src/ScriptSymlinker.php
+++ b/src/ScriptSymlinker.php
@@ -26,12 +26,12 @@ class ScriptSymlinker
         $symlinks = static::getSymlinks($event);
         $fs = new Filesystem();
 
-        foreach ($symlinks as $packageName => $symlink) {
+        foreach ($symlinks as $packageName => $symlinkDefinitions) {
             $package = $event->getComposer()->getRepositoryManager()->getLocalRepository()->findPackage($packageName, '*');
             if ($package !== null) {
                 $packageDir = $event->getComposer()->getInstallationManager()->getInstallPath($package);
                 
-                foreach ($symlink as $target => $link) {
+                foreach ($symlinkDefinitions as $target => $link) {
                     if ($fs->isAbsolutePath($target)) {
                         throw new \InvalidArgumentException(
                             "Invalid symlink target path '$target' for package'{$package->getName()}'."

--- a/src/ScriptSymlinker.php
+++ b/src/ScriptSymlinker.php
@@ -26,12 +26,12 @@ class ScriptSymlinker
         $symlinks = static::getSymlinks($event);
         $fs = new Filesystem();
 
-        foreach ($event->getComposer()->getRepositoryManager()->getLocalRepository()->getPackages() as $package) {
-            if (isset($symlinks[$package->getName()])) {
+        foreach ($symlinks as $packageName => $symlink) {
+            $package = $event->getComposer()->getRepositoryManager()->getLocalRepository()->findPackage($packageName, '*');
+            if ($package !== null) {
                 $packageDir = $event->getComposer()->getInstallationManager()->getInstallPath($package);
-
-                $symlinkDefinitions = $symlinks[$package->getName()];
-                foreach ($symlinkDefinitions as $target => $link) {
+                
+                foreach ($symlink as $target => $link) {
                     if ($fs->isAbsolutePath($target)) {
                         throw new \InvalidArgumentException(
                             "Invalid symlink target path '$target' for package'{$package->getName()}'."


### PR DESCRIPTION
Instead of looping through all packages to see if they have a matching symlink defined in extra I switched it around and search a package for each defined symlink. This improves the speed, especially when having a big dependency list. Your defined symlinks are likely less in numbers then your defined packages ;)